### PR TITLE
updating fork

### DIFF
--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -1003,7 +1003,7 @@ CONTAINS
         Ugrid  = sqrt(u1(kts)**2 + v1(kts)**2)
         cns  = 3.5 * (1.0 - MIN(MAX(Ugrid - Uonset, 0.0)/10.0, 1.0))
         alp1 = 0.23
-        alp2 = 0.35
+        alp2 = 0.30
         alp3 = 2.0
         alp4 = 20.  !10.
         alp5 = alp2 !like alp2, but for free atmosphere
@@ -2629,8 +2629,8 @@ CONTAINS
 !              ql_ice   = sgm(k)*EXP(0.9*q1k-2.6)
               !Reduce ice mixing ratios in the upper troposphere
               low_weight = MIN(MAX(p(k)-40000.0, 0.0),40000.0)/40000.0
-              ql_ice   = low_weight * sgm(k)*EXP(q1k-2.0) &  !low-lev
-                  + (1.-low_weight) * sgm(k)*EXP(0.7*q1k-4.0)!upper-lev
+              ql_ice   = low_weight * sgm(k)*EXP(1.1*q1k-1.6) &  !low-lev
+                  + (1.-low_weight) * sgm(k)*EXP(1.1*q1k-2.8)!upper-lev
            ELSE IF (q1k > 2.) THEN   !supersaturated
               ql_water = sgm(k)*q1k
               ql_ice = MIN(80.*qv(k),0.1)*sgm(k)*q1k
@@ -4635,10 +4635,17 @@ ENDIF
                    radflux=radflux*cp/g*(p1(kk)-p1(kk+1)) ! converts temp/s to W/m^2
                    if (radflux < 0.0 ) radsum=abs(radflux)+radsum
                 ENDDO
-                radsum=MIN(radsum,120.0)
+
+                !More strict limits over land to reduce stable-layer mixouts
+                if ((xland(i,j)-1.5).GE.0)THEN ! WATER
+                   radsum=MIN(radsum,120.0)
+                   bfx0 = max(radsum/rho1(k)/cp,0.)
+                else                           ! LAND
+                   radsum=MIN(0.25*radsum,30.0)!practically turn off over land
+                   bfx0 = max(radsum/rho1(k)/cp - max(sflux,0.0),0.)
+                endif
 
                 !entrainment from PBL top thermals
-                bfx0 = max(radsum/rho1(k)/cp,0.)
                 wm3    = g/thetav(k)*bfx0*MIN(pblh(i,j),1500.) ! this is wstar3(i)
                 wm2    = wm2 + wm3**h2
                 bfxpbl = - ent_eff * bfx0
@@ -5652,7 +5659,7 @@ ENDIF
           !w-dependency for entrainment a la Tian and Kuang (2016)
           !ENT(k,i) = 0.35/(MIN(MAX(UPW(K-1,I),0.75),1.9)*l)
           wmin = 0.3 + l*0.0005 !* MAX(pblh-ZW(k+1), 0.0)/pblh
-          ENT(k,i) = 0.35/(MIN(MAX(UPW(K-1,I),wmin),1.9)*l)
+          ENT(k,i) = 0.31/(MIN(MAX(UPW(K-1,I),wmin),1.9)*l)
           !Entrainment from Negggers (2015, JAMES)
           !ENT(k,i) = 0.02*l**-0.35 - 0.0009
           !Minimum background entrainment 
@@ -5796,22 +5803,22 @@ ENDIF
           !Reminder: w is limited to be non-negative (above)
           aratio   = MIN(UPA(K-1,I)/(1.-UPA(K-1,I)), 0.5) !limit should never get hit
           detturb  = 0.00008
-          oow      = -0.070/MAX(0.9,(0.5*(Wn+UPW(K-1,I))))   !coef for dynamical detrainment rate
-          detrate  = MIN(MAX(oow*(Wn-UPW(K-1,I))/dz(k), detturb), .0004) ! dynamical detrainment rate (m^-1)
+          oow      = -0.060/MAX(1.0,(0.5*(Wn+UPW(K-1,I))))   !coef for dynamical detrainment rate
+          detrate  = MIN(MAX(oow*(Wn-UPW(K-1,I))/dz(k), detturb), .0002) ! dynamical detrainment rate (m^-1)
           detrateUV= MIN(MAX(oow*(Wn-UPW(K-1,I))/dz(k), detturb), .0001) ! dynamical detrainment rate (m^-1) 
-          envm_thl(k)=envm_thl(k) + (0.5*(thl_ent + UPTHL(K-1,I)) - thl(k))*detrate*aratio*dzp
+          envm_thl(k)=envm_thl(k) + (0.5*(thl_ent + UPTHL(K-1,I)) - thl(k))*detrate*aratio*MIN(dzp,300.)
           qv_ent = 0.5*(MAX(qt_ent-qc_ent,0.) + MAX(UPQT(K-1,I)-UPQC(K-1,I),0.))
-          envm_sqv(k)=envm_sqv(k) + (qv_ent-QV(K))*detrate*aratio*dzp
+          envm_sqv(k)=envm_sqv(k) + (qv_ent-QV(K))*detrate*aratio*MIN(dzp,300.)
           IF (UPQC(K-1,I) > 1E-8) THEN
              IF (QC(K) > 1E-6) THEN
                 qc_grid = QC(K)
              ELSE
                 qc_grid = cldfra_bl1d(k)*qc_bl1d(K)
              ENDIF
-             envm_sqc(k)=envm_sqc(k) + MAX(UPA(K-1,I)*0.5*(QCn + UPQC(K-1,I)) - qc_grid, 0.0)*detrate*aratio*dzp
+             envm_sqc(k)=envm_sqc(k) + MAX(UPA(K-1,I)*0.5*(QCn + UPQC(K-1,I)) - qc_grid, 0.0)*detrate*aratio*MIN(dzp,300.)
           ENDIF
-          envm_u(k)  =envm_u(k)   + (0.5*(Un + UPU(K-1,I)) - U(K))*detrateUV*aratio*dzp
-          envm_v(k)  =envm_v(k)   + (0.5*(Vn + UPV(K-1,I)) - V(K))*detrateUV*aratio*dzp
+          envm_u(k)  =envm_u(k)   + (0.5*(Un + UPU(K-1,I)) - U(K))*detrateUV*aratio*MIN(dzp,300.)
+          envm_v(k)  =envm_v(k)   + (0.5*(Vn + UPV(K-1,I)) - V(K))*detrateUV*aratio*MIN(dzp,300.)
 
           IF (Wn > 0.) THEN
              !Update plume variables at current k index


### PR DESCRIPTION
…1177)

TYPE: enhancement

KEYWORDS: stable layers, clouds, radiation 

SOURCE: Joseph Olson (NOAA)

DESCRIPTION OF CHANGES:
Two issues were revealed in recent testing:
1) While revisiting important case studies, we found that the maintenance of stable layers were degraded due to a combination of the addition of the top-down mixing from cloud-top radiative cooling and a small increase in the buoyancy mixing length scale. The following tweaks allowed us to regain the original HRRR performance (see figure 1):

- Reduction of top-down mixing from cloud-top radiative cooling over land. Although we don’t like to have land-water dependencies, this will have to do until a more general solution is found.
- Revert constant alp2 back to 0.3 from 0.35 as it was prior to v.4.2.

2) Solar forecast verification were showing a slight degradation relative to the v4.1 configuration. This is partly due to a reduction of the analytically prescribed subgrid-scale qi (qi_bl), which we think is justifiable, but we think we reduced it too much. Also, the mass-flux plumes were not penetrating the LCL as often as before due to the drying associated with the parameterized subsidence. The first two changes listed below were made to alleviate this problem and the third change is a necessary subsequent modification to go with the second change and also helps for coarse vertical grid spacing. Figure 2 shows evidence that these changes get the SWDOWN bias back to where we were before (or very slightly better in the afternoon-evening) but the MAE is still about the same.

- We increased the analytical specification for SGS ice mixing ratios (qi_bl), although I suspect it may still be too small. This at least helps, but in pure ice clouds (i.e. cirrus), we still have more SWDOWN than in previous versions.
- We also decreased the entrainment rates to allow plumes to penetrate a little higher – more likely to penetrate the LCL, condense, and form shallow cumulus.
- As plumes penetrate into higher model levels, where dz can become very large (>300 m), the detrainment rates that work well for moderate and small dz (< 300 m) result in excessive dynamical detrainment further aloft. This would have been notice much earlier if we tested with a variety of vertical grid spacing but we currently do not. We added some limits in the detrainment section to address this issue and also slightly reduced come coefficients to minimize the chance of the dynamical detrainment to contribute to high RH biases at or above 700 mb.

![Screen Shot 2020-04-21 at 2 14 26 PM](https://user-images.githubusercontent.com/14096622/79909588-7955d980-83da-11ea-8277-3fd33c2816bb.png)
Figure 1. Stratus-topped stable layer mix-out over the front range. The HRRRv4 actually holds onto the clouds (as shown by the ceilings) and with the mods described above, now the v4.2 version of the MYNN does as well.

![Screen Shot 2020-04-21 at 2 17 16 PM](https://user-images.githubusercontent.com/14096622/79909818-da7dad00-83da-11ea-9da6-83a6e4841aba.png)
Figure 2. SWDOWN verification against SURFAD for a 6-day HRRR retrospective run. Red is HRRRv4, blue is the proposed v4.2 MYNN. With the mods described above, the HRRR can at least match it's former performance. 

LIST OF MODIFIED FILES: M phys/module_bl_mynn.F

TESTS CONDUCTED:
Jenkins tests all PASS.

Use this template to give a detailed message describing the change you want to make to the code.
If you are unclear on what should be written here, see  https://github.com/wrf-model/WRF/wiki/Making-a-good-pull-request-message for more guidance

The title of this pull request should be a brief "purpose" for this change.

--- Delete this line and those above before hitting "Create pull request" ---

TYPE: choose one of [bug fix, enhancement, new feature, feature removed, no impact, text only]

KEYWORDS: approximately 3 to 6 words (more is always better) related to your commit, separated by commas

SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev committee member

DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.

ISSUE: For use when this PR closes an issue. For issue number 123
```
Fixes #123
```

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!

RELEASE NOTE: Optional, as appropriate. Delete if not used. Included only once for new features requiring several merge cycles. Changes to default behavior are also note worthy.
